### PR TITLE
Add vagrant support & fix provisioner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ spec/graph_example2.xml
 spec/spellcheck_example.xml
 spec/unauthorized_access.xml
 spec/unknown.xml
+
+.vagrant/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,13 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# See Vagrantfile.example for additional options.
+Vagrant.configure(2) do |config|
+  config.vm.box = "hashicorp/precise64"
+
+  config.vm.synced_folder "../rag", "/home/vagrant/rag"
+  config.vm.synced_folder "../hw", "/home/vagrant/hw"
+  config.vm.synced_folder "../rottenpotatoes", "/home/vagrant/rottenpotatoes"
+
+  config.vm.provision "shell", path: "ubuntu-install.sh", privileged: false
+end

--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -1,0 +1,74 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Don't delete or edit this file -- it is here to make it easier to find options
+# to add to the Vagrantfile in the future.
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "hashicorp/precise64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   sudo apt-get update
+  #   sudo apt-get install -y apache2
+  # SHELL
+end

--- a/ubuntu-install.sh
+++ b/ubuntu-install.sh
@@ -1,70 +1,97 @@
 #!/bin/bash
 # Simple autograder setup.sh for configuring Ubuntu 12.04 LTS EC2 instance
 
-sudo apt-get install -y git
-\curl -L https://get.rvm.io | bash -s stable  --ruby=1.9.3
-source ~/.rvm/scripts/rvm
+set -e
 
+# get clone only if missing, then cd into it
+git-clone-ifmissing-cd() {
+    if ! test -e "$2"; then
+        verbose-short git clone "$1" "$2"
+    fi
+    verbose-short cd "$2"
+}
+
+# gem install only if not installed
+gem-install-ifmissing() {
+  if ! gem list -i $@ > /dev/null; then
+    verbose-short gem install $@ --no-doc
+  fi
+}
+
+# bundle install only if not installed
+bundle-install-ifmissing() {
+  if ! bundle check > /dev/null; then
+    verbose-short bundle install
+  fi
+}
+
+# Prepend `verbose` to any command to have it echoed as well as run.
+verbose() {
+  echo 1>&2 ' '
+  echo 1>&2 $ $@
+  $@
+}
+
+verbose-short() {
+  echo 1>&2 $ $@
+  $@
+}
+
+# install things
+verbose sudo apt-get install -y git curl
+if ! test -e ~/.rvm/scripts/rvm; then
+    verbose curl -sSL https://rvm.io/mpapis.asc | verbose-short gpg --import -
+    verbose curl -sSL https://get.rvm.io | verbose-short bash -s stable --quiet-curl --ruby=1.9.3
+    # --rubygems=2.1.11 is for ZenTest in ~/rag
+fi
+verbose source ~/.rvm/scripts/rvm
+verbose rvm rubygems 2.1.11 --force
 # this needed for HW4 and must be installed before some other versions of libv8 are pulled in?
-gem install therubyracer -v '0.9.10'
+verbose gem-install-ifmissing therubyracer -v '0.9.10'
 
-git clone https://github.com/saasbook/rag.git
+# rag
+verbose git-clone-ifmissing-cd https://github.com/saasbook/rag.git ~/rag
+verbose gem-install-ifmissing ruby-debug19  # http://stackoverflow.com/a/21466030/782045
+verbose bundle-install-ifmissing
+# There used to be an issue with the above command. Here are solutions that
+# didn't seem to work:
+# https://github.com/seattlerb/zentest/issues/48
+# http://stackoverflow.com/a/23810004/782045
+# gem install debugger -v '1.6.2' --no-doc
+verbose bundle exec rspec --format progress --out /dev/null
 
-cd rag
-
-bundle update --source ZenTest
-
-bundle exec rspec
-
-cd ..
-git clone https://github.com/saasbook/hw.git
-
-cd hw
-bundle install
-./check_all_solutions
-
-cd ..
-cd rag
-cd spec
+# hw
+verbose git-clone-ifmissing-cd https://github.com/saasbook/hw.git ~/hw
+verbose bundle-install-ifmissing
+verbose ./check_all_solutions.sh
 
 # required to allow Oracle of Bacon grader to run ...
-ln -s /home/ubuntu/hw/oracle-of-bacon/public/spec/graph_example.xml
-ln -s /home/ubuntu/hw/oracle-of-bacon/public/spec/graph_example2.xml
-ln -s /home/ubuntu/hw/oracle-of-bacon/public/spec/spellcheck_example.xml
-ln -s /home/ubuntu/hw/oracle-of-bacon/public/spec/unauthorized_access.xml
-ln -s /home/ubuntu/hw/oracle-of-bacon/public/spec/unknown.xml
-
-#
-cd ../..
+verbose \
+ln -sf ~/hw/oracle-of-bacon/public/spec/graph_example.xml \
+       ~/hw/oracle-of-bacon/public/spec/graph_example2.xml \
+       ~/hw/oracle-of-bacon/public/spec/spellcheck_example.xml \
+       ~/hw/oracle-of-bacon/public/spec/unauthorized_access.xml \
+       ~/hw/oracle-of-bacon/public/spec/unknown.xml \
+       ~/rag/spec
 
 # To get a nice footer for screen for .screenrc
-
-cp rag/.screenrc .screenrc
+verbose cp -f ~/rag/.screenrc ~/.screenrc
 
 # to set up HW3 we must import the gemset
 # this should be done in a second screen window
+verbose cd ~/hw/bdd-cucumber/public/rottenpotatoes/
+# /bin/bash --login
+verbose rvm gemset create rag3
+verbose rvm gemset import rag3
+verbose rvm gemset use rag3
 
-cd hw/bdd-cucumber/public/rottenpotatoes/
-/bin/bash --login
-rvm gemset create rag3
-rvm gemset import rag3
-rvm gemset use rag3
-
-# also we need:
-
-cd ~
-sudo apt-get install libxslt-dev libxml2-dev
-git clone https://github.com/saasbook/rottenpotatoes.git
-cd rottenpotatoes/
-git checkout -b hw3_solution origin/hw3_solution
-bundle install
-bundle exec rake db:create
-bundle exec rake db:migrate
-bundle exec rake db:test:prepare
-
+# rottenpotatoes
+verbose sudo apt-get install -y libxslt-dev libxml2-dev
+verbose git-clone-ifmissing-cd https://github.com/saasbook/rottenpotatoes.git ~/rottenpotatoes
+verbose git checkout hw3_solution
+verbose bundle-install-ifmissing
+verbose bundle exec rake db:create
+verbose bundle exec rake db:migrate
+verbose bundle exec rake db:test:prepare
 # then the spork command can be run
-bundle exec spork cucumber
-
-
-
-
+# verbose bundle exec spork cucumber


### PR DESCRIPTION
- Add Vagrantfile with:
  - Ubuntu 12.04 (precise), according to `ubuntu-install.sh`
  - synced folders for repos
    (they are private so the guest can't clone them)
  - provisoner: `ubuntu-install.sh`
- Fix `ubuntu-install.sh`
  - various gem/bundler conflicts
  - use repos that are already cloned bc they are private (above)
- Improve `ubuntu-install.sh`
  - fast exist on error `set -e`
  - echo commands when relevant using `verbose`
  - DRY macros (e.g., the `ifmissing` functions)
  - make workingdir changes easier to read

In addition, I've verified that this setup will provision with no errors and with all called RSpec tests passing.

```
All you have to do is clone these three repos in the same directory:
- hw
- rottenpotatoes
- rag  <- then cd into here and run: vagrant up
```
