### PR TITLE
Update to ruby 2.0.0, depends on changes in xqueue-ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ install:
   - rvm use 2.0.0
   - bundle install
 script:
-  - bundle exec rspec spec
-  - bundle exec cucumber
+  - rspec spec
+  - cucumber features
 #notifications:
 #  email: false
 #  slack: cs169dev:OPMf1tPzfO3a4gz6gGTOFV7w

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 language: ruby
-rvm: 
-  - 1.9.3
+rvm:
+  - "1.9.3"
+  - "2.0.0"
+before_install:
+  - rvm use 1.9.3
+  - gem install ruby-debug19
+install:
+  - rvm use 2.0.0
+  - bundle install
 script:
   - bundle exec rspec spec
   - bundle exec cucumber
-install:
-  - gem install ruby-debug19
-  - bundle install
-notifications:
-  email: false
-  slack: cs169dev:OPMf1tPzfO3a4gz6gGTOFV7w
+#notifications:
+#  email: false
+#  slack: cs169dev:OPMf1tPzfO3a4gz6gGTOFV7w

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ rvm:
 #  - rvm use 2.0.0
 #  - bundle install
 script:
-  - rspec spec
-  - cucumber features
+  - bundle exec rspec spec
+  - bundle exec cucumber features
 #notifications:
 #  email: false
 #  slack: cs169dev:OPMf1tPzfO3a4gz6gGTOFV7w

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: ruby
 rvm:
-  - "1.9.3"
+# try eliminate ruby-debug and debugger for switch to ruby2
+#  - "1.9.3"
   - "2.0.0"
-before_install:
-  - rvm use 1.9.3
-  - gem install ruby-debug19
-install:
-  - rvm use 2.0.0
-  - bundle install
+#before_install:
+#  - rvm use 1.9.3
+#  - gem install ruby-debug19
+#install:
+#  - rvm use 2.0.0
+#  - bundle install
 script:
   - rspec spec
   - cucumber features

--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,14 @@ gem 'metric_fu'
 gem 'mechanize'
 gem 'octokit'
 gem 'term-ansicolor'
-gem 'xqueue_ruby', :git => 'https://github.com/zhangaaron/xqueue-ruby'
+# temporarily point at apelade repo with ruby-debug removed
+#gem 'xqueue_ruby', :git => 'https://github.com/zhangaaron/xqueue-ruby'
+gem 'xqueue_ruby', :git => 'https://github.com/apelade/xqueue-ruby'
 gem 'activerecord'
 
 group :development, :testing do
   gem 'ZenTest'
+  # remove debugger
   #gem 'debugger'
   gem 'simplecov'
   gem 'fakeweb'

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'activerecord'
 
 group :development, :testing do
   gem 'ZenTest'
-  gem 'debugger'
+  #gem 'debugger'
   gem 'simplecov'
   gem 'fakeweb'
   gem 'simplecov-rcov'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby "2.0.0"
+
 gem 'rspec'
 gem 'metric_fu'
 gem 'mechanize'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,6 +189,3 @@ DEPENDENCIES
   simplecov-rcov
   term-ansicolor
   xqueue_ruby!
-
-BUNDLED WITH
-   1.10.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,19 +47,12 @@ GEM
     code_metrics (0.1.1)
     coderay (1.1.0)
     colored (1.2)
-    columnize (0.3.6)
     cucumber (1.3.10)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
       gherkin (~> 2.12)
       multi_json (>= 1.7.5, < 2.0)
       multi_test (>= 0.0.2)
-    debugger (1.6.2)
-      columnize (>= 0.3.1)
-      debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.2.3)
-    debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.2.3)
     diff-lcs (1.2.4)
     domain_name (0.5.13)
       unf (>= 0.0.5, < 1.0.0)
@@ -186,7 +179,6 @@ DEPENDENCIES
   activerecord
   addressable
   cucumber
-  debugger
   fakeweb
   mechanize
   metric_fu
@@ -196,3 +188,6 @@ DEPENDENCIES
   simplecov-rcov
   term-ansicolor
   xqueue_ruby!
+
+BUNDLED WITH
+   1.10.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 GIT
-  remote: https://github.com/zhangaaron/xqueue-ruby
-  revision: b49b2f83b5178e5d5ede73b0e0189c457633b75a
+  remote: https://github.com/apelade/xqueue-ruby
+  revision: 36d4486d458b8ee88279efb568e8e4648eb08658
   specs:
     xqueue_ruby (0.0.1)
+      activemodel
       builder
       getopt
 

--- a/grade
+++ b/grade
@@ -4,7 +4,7 @@
 # An example use of the Ruby autograder
 
 require './lib/auto_grader.rb'
-require 'ruby-debug'
+#require 'ruby-debug'
 
 def grade(file,spec)
 end

--- a/lib/auto_grader.rb
+++ b/lib/auto_grader.rb
@@ -1,4 +1,4 @@
-require 'ruby-debug'
+#require 'ruby-debug'
 
 class AutoGrader
   class AutoGrader::NoSuchGraderError < StandardError ; end

--- a/lib/edx_client.rb
+++ b/lib/edx_client.rb
@@ -6,7 +6,7 @@ require 'net/http'
 require 'base64'
 require 'cgi'
 require 'date'
-require 'ruby-debug'
+#require 'ruby-debug'
 
 require_relative 'rag_logger'
 require_relative 'edx_controller'

--- a/lib/graders/migration_grader/migration_grader.rb
+++ b/lib/graders/migration_grader/migration_grader.rb
@@ -1,4 +1,4 @@
-require 'ruby-debug'
+#require 'ruby-debug'
 require 'open3'
 require 'yaml'
 require 'term/ansicolor'

--- a/lib/run_with_timeout.rb
+++ b/lib/run_with_timeout.rb
@@ -1,7 +1,7 @@
 # Courtesy of https://gist.github.com/1032297
 require 'open3'
 require 'timeout'
-require 'ruby-debug'
+#require 'ruby-debug'
 
 # Runs a specified shell command in a separate thread.
 # If it exceeds the given timeout in seconds, kills it.


### PR DESCRIPTION
### NOTE: Pointed at my apelade/xqueue-ruby repo, so don't leave it like that... only accept after https://github.com/zhangaaron/xqueue-ruby/pull/1

Also removed debugger stuff - byebug is the debugger for ruby2
#### There are still 2 of the cucumber tests failing but 20 pass so those need to be checked out:

https://travis-ci.org/zhangaaron/rag/builds/67779653#L176

```
Failing Scenarios:
cucumber features/student_feedback.feature:10 # Scenario: correctly reports grace period
cucumber features/student_feedback.feature:14 # Scenario: correctly reports late period
23 scenarios (2 failed, 1 pending, 20 passed)
89 steps (2 failed, 1 skipped, 1 pending, 85 passed)
0m20.856s
The command "bundle exec cucumber features" exited with 1.
Done. Your build exited with 1.
```
#### Forgiving those errors for now, you can see the ruby-intro-ci with ruby2 here: https://github.com/saasbook/ruby-intro-ci/pull/2
