### PR TITLE
XQueue+GitHub initial work

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'term-ansicolor'
 gem 'xqueue_ruby', :git => 'https://github.com/zhangaaron/xqueue-ruby'
 gem 'activerecord'
 gem 'ruby-filemagic'
+gem 'git'
 
 group :development, :testing do
   gem 'ZenTest'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,7 @@ GEM
     getopt (1.4.2)
     gherkin (2.12.2)
       multi_json (~> 1.3)
+    git (1.2.9.1)
     globalid (0.3.5)
       activesupport (>= 4.1.0)
     hirb (0.7.3)
@@ -301,6 +302,7 @@ DEPENDENCIES
   cucumber-rails
   fakefs
   fakeweb
+  git
   mechanize
   metric_fu
   octokit
@@ -313,4 +315,4 @@ DEPENDENCIES
   xqueue_ruby!
 
 BUNDLED WITH
-   1.10.5
+   1.10.6

--- a/lib/submission/xqueue.rb
+++ b/lib/submission/xqueue.rb
@@ -12,6 +12,11 @@ module Submission
     STRFMT = "%Y-%m-%d-%H-%M-%S"
     def initialize(config_hash)
       super(config_hash)
+      # @halt = conf['halt']  # TODO: figure out what this is for
+      initialize_x_queue(config_hash)
+    end
+
+    def initialize_x_queue(config_hash)
       @x_queue = ::XQueue.new(*create_xqueue_hash(config_hash))
     end
 

--- a/lib/submission/xqueue_github.rb
+++ b/lib/submission/xqueue_github.rb
@@ -1,0 +1,40 @@
+require 'xqueue_ruby'
+require_relative 'xqueue'
+
+module SubmissionAdapter
+  class XqueueGithub < Xqueue
+    def initialize_x_queue(config_hash)
+      @x_queue = ::XQueue.new(*create_xqueue_hash(config_hash), retrieve_files=false)
+    end
+
+    def next_submission_with_assignment
+      submission = @x_queue.get_submission
+      return if submission.nil?
+      submission.assignment = Assignment::Xqueue.new(submission)
+
+      location = File.join(
+        ENV['BASE_FOLDER'] + submission.student_id],
+        submission.assignment.assignment_name,
+        Time.new.strftime(STRFMT)
+      )
+      # FileUtils.mkdir_p location
+      Git.clone(submission.GIT_URL_FIELD, location)  # TODO: fill this in
+      submission.files = { "files": location }
+      submission
+    end
+  end
+end
+
+
+# first attempt
+# submission = super
+# repo = submission.body['github_repo']
+# branch = submission.body['github_branch']
+# # TODO: get rid of this test access_token
+# url = [
+#   "https://api.github.com/repos/#{repo}/zipball/#{branch}?",
+#   "access_token=605391497040d15aacac18b618dc605637be4566",
+# ].join ''
+# submission.files = [url]
+# submission.fetch_files!
+# submission


### PR DESCRIPTION
Progress:
- create `SubmissionAdapter::XqueueGithub` < `Xqueue`
- turn off `retrieve_files`
- use `Git#clone` to retrieve files
- `@files["github"]` is set to location on disk

Missing:
- figure out how to change submission from file upload to textbox
- the machine user needs access to all the repos being cloned. Need to write documentation for how to tell students to add autograder's public key as a deploy key
